### PR TITLE
codam greeter temporary patch

### DIFF
--- a/ml_lock.py
+++ b/ml_lock.py
@@ -270,8 +270,9 @@ class LockScreen:
             text=f"{timer_text}",
             foreground='#ffffff'
         )
+        
         x, y = pag.size()
-        pag.moveTo(random.randint(0, x), random.randint(0, y))
+        pag.moveTo(random.randint(1, x - 1), random.randint(1, y - 1))
         self.root.after(1000, self.update_timer)
     
     def start_countdown(self):

--- a/ml_lock.py
+++ b/ml_lock.py
@@ -14,6 +14,7 @@ import getpass
 import json
 import sys
 import re
+import pyautogui as pag
 
 def get_password_hash(password):
     salt = b'ml_lock_salt'
@@ -269,6 +270,8 @@ class LockScreen:
             text=f"{timer_text}",
             foreground='#ffffff'
         )
+        x, y = pag.size()
+        pag.moveTo(random.randint(0, x), random.randint(0, y))
         self.root.after(1000, self.update_timer)
     
     def start_countdown(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pillow
 python-xlib
 wmctrl
+pyautogui


### PR DESCRIPTION
small patch to get the lockscreen to work for the codam greeter idle, ft_lock is not used in it, it instead uses a ping with `xprintidle`, I just make the mouse move for now, seems to work fine